### PR TITLE
fix: Generate and export types, use .cjs file extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "pegjs": "^0.10.0",
         "rimraf": "^2.7.1",
         "rollup": "^4.22.4",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.5.3",
         "uglify-js": "^3.6.2",
         "viz.js": "^2.1.2"
@@ -5505,6 +5506,29 @@
         "@rollup/rollup-win32-ia32-msvc": "4.24.0",
         "@rollup/rollup-win32-x64-msvc": "4.24.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-dts": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.1.1.tgz",
+      "integrity": "sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "magic-string": "^0.30.10"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.24.2"
+      },
+      "peerDependencies": {
+        "rollup": "^3.29.4 || ^4",
+        "typescript": "^4.5 || ^5.0"
       }
     },
     "node_modules/run-parallel": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "jssm-viz",
-  "version": "5.99.0",
+  "version": "5.101.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jssm-viz",
-      "version": "5.99.0",
+      "version": "5.101.0",
       "license": "MIT",
       "dependencies": {
         "better_git_changelog": "^1.6.2",
         "eslint": "^8.15.0",
-        "jssm": "^5.99.0",
+        "jssm": "^5.101.0",
         "reduce-to-639-1": "^1.1.0",
         "text_audit": "^0.9.2"
       },
@@ -4136,9 +4136,10 @@
       }
     },
     "node_modules/jssm": {
-      "version": "5.100.0",
-      "resolved": "https://registry.npmjs.org/jssm/-/jssm-5.100.0.tgz",
-      "integrity": "sha512-eRzhaDWALNZWPV0BaP+Wml6UCFNmp+/UG0+ZlfUiyQeubPiiW8u5FHq39+58r7AP9e1CCiulP3HmUsG5QzT6eA==",
+      "version": "5.103.0",
+      "resolved": "https://registry.npmjs.org/jssm/-/jssm-5.103.0.tgz",
+      "integrity": "sha512-nsRXagHl1XqSL0Vtttm3Rf3RLJdJuqtylLJ4KRuvih+XLyhQXfmCg5k7WrpCgN+cTUQWpcOy6yoGQqemZ9bQQA==",
+      "license": "MIT",
       "dependencies": {
         "better_git_changelog": "^1.6.1",
         "circular_buffer_js": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,17 @@
   "description": "Visualization of JSSM machines using viz.js",
   "main": "dist/jssm-viz.cjs.cjs",
   "module": "dist/jssm-viz.es6.js",
+  "exports": {
+    "require": {
+      "types": "./dist/jssm-viz.d.cts",
+      "default": "./dist/jssm-viz.cjs.cjs"
+    },
+    "import": {
+      "types": "./dist/jssm-viz.es6.d.ts",
+      "default": "./dist/jssm-viz.es6.js"
+    },
+    "browser": "./dist/jssm-viz.iife.js"
+  },
   "scripts": {
     "test": "jest --verbose",
     "clean": "rimraf build -f && rimraf dist -f && rimraf docs -f && mkdir build && cd build && mkdir terser && cd .. && mkdir dist && mkdir docs && cd docs && mkdir docs && cd ../src/ts && rimraf -f generated_code && mkdir generated_code && cd ../..",
@@ -74,6 +85,7 @@
     "pegjs": "^0.10.0",
     "rimraf": "^2.7.1",
     "rollup": "^4.22.4",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.5.3",
     "uglify-js": "^3.6.2",
     "viz.js": "^2.1.2"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.101.0",
   "type": "module",
   "description": "Visualization of JSSM machines using viz.js",
-  "main": "dist/jssm-viz.cjs.js",
+  "main": "dist/jssm-viz.cjs.cjs",
   "module": "dist/jssm-viz.es6.js",
   "scripts": {
     "test": "jest --verbose",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,12 @@
 
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs    from '@rollup/plugin-commonjs';
+import dts         from "rollup-plugin-dts";
 
 
 
 
-
-const es6config = {
+const es6config = [{
 
   input     : 'build/typescript/jssm-viz.js',
 
@@ -35,13 +35,26 @@ const es6config = {
 
   ]
 
-};
+}, {
+
+  input: 'build/typescript/jssm-viz.d.ts',
+
+  output: { 
+    file   : './build/rollup/jssm-viz.es6.d.ts',
+    format : 'es'
+  },
+
+  plugins : [
+
+    dts()
+  ]}
+];
 
 
 
 
 
-const cjsconfig = {
+const cjsconfig = [{
 
   input     : 'build/typescript/jssm-viz.js',
 
@@ -70,13 +83,26 @@ const cjsconfig = {
 
   ]
 
-};
+}, {
+
+  input: 'build/typescript/jssm-viz.d.ts',
+
+  output: { 
+    file   : './build/rollup/jssm-viz.cjs.d.cts',
+    format : 'cjs'
+  },
+
+  plugins : [
+
+    dts()
+  ]}
+];
 
 
 
 
 
-const iifeconfig = {
+const iifeconfig = [{
 
   input     : 'build/typescript/jssm-viz.js',
 
@@ -105,10 +131,10 @@ const iifeconfig = {
 
   ]
 
-};
+}];
 
 
 
 
 
-export default [ es6config, cjsconfig, iifeconfig ];
+export default [ ...es6config, ...cjsconfig, ...iifeconfig ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,7 +46,7 @@ const cjsconfig = {
   input     : 'build/typescript/jssm-viz.js',
 
   output    : {
-    file      : 'build/rollup/jssm-viz.cjs.js',
+    file      : 'build/rollup/jssm-viz.cjs.cjs',
     format    : 'cjs',
     name      : 'jssm_viz',
     sourcemap : true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,7 +49,7 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     "sourceMap": true,                                   /* Create source map files for emitted JavaScript files. */


### PR DESCRIPTION
## The bug

jssm-viz has `type: module` in package.json, but exports CJS with .js file extensions, which fail to run in some configurations. Additionally, types are not generated or exported which causes TypeScript to treat everything as `any` or in some configurations fail to compile.

## This change

- Updates the rollup config to use .cjs file extensions with CJS output.
- Updates the tsconfig to emit type declarations.
- Adds a type generation step to the rollup config to create ESM and CJS types
- Updates the package.json main field to point to new CJS file name.
- Adds an exports field to the package.json that points to the types and entry points for both CJS and ESM.

## To reproduce the bug

Here's a minimal repro project: https://github.com/tylerbutler/jssm-node16

`npm run build` or `npm run diagrams` in that project will produce this error:

```
> jssm-viz -i "./src/*.fsl"

/home/tylerbu/code/jssm-node16/node_modules/jssm-viz-cli/dist/js/cli.js:6
const jssm_viz_1 = require("jssm-viz");
                   ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /home/tylerbu/code/jssm-node16/node_modules/jssm-viz/dist/jssm-viz.cjs.js from /home/tylerbu/code/jssm-node16/node_modules/jssm-viz-cli/dist/js/cli.js not supported.
jssm-viz.cjs.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename jssm-viz.cjs.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /home/tylerbu/code/jssm-node16/node_modules/jssm-viz/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at Object.<anonymous> (/home/tylerbu/code/jssm-node16/node_modules/jssm-viz-cli/dist/js/cli.js:6:20) {
  code: 'ERR_REQUIRE_ESM'
}
```

## Related issues

I noticed that the tests in jssm-viz don't appear to run. Jest errors out immediately because the config file is using the .js file extension and is thus expected to be in ESM. Renaming the config file further revealed that the ts-jest dependency is missing. I installed that dep and updated the config, but the tests are now failing with an unspecified error. I'll look into those more, but the changes in this PR are needed for the tests to work, I think. Otherwise ts-jest will fail with an error like:

```
> jest --verbose

 FAIL  src/ts/tests/general.spec.ts
  ● Test suite failed to run

    src/ts/tests/general.spec.ts:3:21 - error TS7016: Could not find a declaration file for module '../../../dist/jssm-viz.cjs.js'. '/home/tylerbu/code/jssm-viz/dist/jssm-viz.cjs.js' implicitly has an 'any' type.

    import * as jv from '../../../dist/jssm-viz.cjs.js';
```